### PR TITLE
Add issue template

### DIFF
--- a/.github /ISSUE_TEMPLATE/blank_issue.yml
+++ b/.github /ISSUE_TEMPLATE/blank_issue.yml
@@ -1,0 +1,33 @@
+name: "📂 Blank Issue"
+description: "Open a general issue without a specific template"
+title: "[General] <short-title>"
+labels: ["needs-triage"]
+assignees: []
+
+body:
+  - type: dropdown
+    id: category
+    attributes:
+      label: "📂 Category"
+      options:
+        - Enhancement
+        - Refactor
+        - Security
+        - Design
+        - Other
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "📘 Additional Context (Optional)"
+      description: "Add any other context, links, screenshots, or info that might be relevant."
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "🙌 Contributor Checklist (Optional)"
+      options:
+        - label: "I have searched existing issues to avoid duplicates"
+        - label: "I agree to follow this project's Code of Conduct"
+        - label: "I am a GSSOC'25 contributor"
+        - label: "I want to work on this issue"

--- a/.github /ISSUE_TEMPLATE/bug_report.yml
+++ b/.github /ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: "🐞 Bug Report"
+description: "Report a bug to help improve the project"
+title: "[BUG] "
+labels: ["bug"]
+assignees: []
+
+body:
+  - type: checkboxes
+    id: search
+    attributes:
+      label: "🔍 Have You Searched Existing Issues?"
+      options:
+        - label: "I have searched the existing issues to avoid duplicates"
+          required: true
+
+  - type: textarea
+    id: describe_bug
+    attributes:
+      label: "🐞 Describe the Bug"
+      description: "What is happening and what should happen instead?"
+      placeholder: "Explain the bug in detail."
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "▶️ Steps to Reproduce"
+      description: "Step-by-step instructions to reproduce the bug"
+      placeholder: "1. Go to '...'\n2. Click on '...'\n3. Scroll to '...'\n4. See error"
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "✅ Expected Behavior"
+      description: "What should have happened?"
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: "🖼️ Screenshots (If applicable)"
+      description: "Add screenshots to help explain the issue"
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: "📘 Additional Context"
+      description: "Any other details that might help"
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "🙌 Contributor Checklist"
+      options:
+        - label: "I agree to follow this project's Code of Conduct"
+        - label: "I am a GSSOC'25 contributor"
+        - label: "I want to work on this issue"

--- a/.github /ISSUE_TEMPLATE/custom_issue.yml
+++ b/.github /ISSUE_TEMPLATE/custom_issue.yml
@@ -1,0 +1,42 @@
+name: "🛠️ Custom Issue"
+description: "For requests or suggestions that don't fit into bug, feature, or docs"
+title: "[Custom] <short-title>"
+labels: ["custom", "needs-triage"]
+assignees: []
+
+body:
+  - type: checkboxes
+    id: search
+    attributes:
+      label: "🔍 Have You Searched Existing Issues?"
+      options:
+        - label: "I have searched the existing issues to avoid duplicates"
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: "📝 Issue Summary"
+      description: "Provide a short summary of the custom issue"
+      placeholder: "Example: Enhancement suggestion for the search functionality."
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "🔍 Issue Description"
+      description: "Describe the issue or suggestion in detail. Include any relevant context."
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: "💡 Proposed Solution (Optional)"
+      description: "If you have any ideas or suggestions for solving this issue, describe them here."
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "🙌 Contributor Checklist"
+      options:
+        - label: "I agree to follow this project's Code of Conduct"
+        - label: "I am a GSSOC'25 contributor"
+        - label: "I want to work on this issue"

--- a/.github /ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github /ISSUE_TEMPLATE/documentation_update.yml
@@ -1,0 +1,36 @@
+name: "📑 Documentation Update"
+description: "Suggest changes or improvements to documentation"
+title: "[Docs] <short-title>"
+labels: ["documentation", "needs-triage"]
+assignees: []
+
+body:
+  - type: checkboxes
+    id: search
+    attributes:
+      label: "🔍 Have You Searched Existing Issues?"
+      options:
+        - label: "I have searched the existing issues to avoid duplicates"
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: "📝 What's wrong with the existing documentation?"
+      description: "Describe what needs to be fixed, added, or removed."
+
+  - type: textarea
+    id: material
+    attributes:
+      label: "📎 Supporting Material"
+      description: "Attach screenshots, videos, or links that help explain your update."
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "🙌 Contributor Checklist"
+      options:
+        - label: "I have reviewed the existing documentation"
+        - label: "I agree to follow this project's Code of Conduct"
+        - label: "I am a GSSOC'25 contributor"
+        - label: "I want to work on this issue"

--- a/.github /ISSUE_TEMPLATE/feature_request.yml
+++ b/.github /ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: "✨ Feature Request"
+description: "Propose a new feature or enhancement"
+title: "[Feature] <short-title>"
+labels: ["enhancement", "needs-triage"]
+assignees: []
+
+body:
+  - type: checkboxes
+    id: search
+    attributes:
+      label: "🔍 Have You Searched Existing Issues?"
+      options:
+        - label: "I have searched the existing issues to avoid duplicates"
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: "💡 Problem Description"
+      description: "What problem are you facing that this feature would solve?"
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: "✅ Proposed Solution"
+      description: "Describe the feature you'd like to see added."
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "🔄 Alternatives Considered"
+      description: "Are there other ways you thought about solving this?"
+
+  - type: textarea
+    id: visuals
+    attributes:
+      label: "🖼️ Screenshots or Diagrams (Optional)"
+      description: "Attach visuals or examples to support your idea."
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "🙌 Contributor Checklist"
+      options:
+        - label: "I have checked for similar feature requests"
+        - label: "I agree to follow this project's Code of Conduct"
+        - label: "I am a GSSOC'25 contributor"
+        - label: "I want to work on this issue"

--- a/.github /ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github /ISSUE_TEMPLATE/performance_issue.yml
@@ -1,0 +1,47 @@
+name: "⚡ Performance Issue"
+description: "Report performance issues such as lag or slowness"
+title: "[Performance] <short-title>"
+labels: ["performance", "needs-triage"]
+assignees: []
+
+body:
+  - type: checkboxes
+    id: search
+    attributes:
+      label: "🔍 Have You Searched Existing Issues?"
+      options:
+        - label: "I have searched the existing issues to avoid duplicates"
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "📉 Describe the Performance Issue"
+      description: "What is slow or lagging? When does it happen?"
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "🧪 Environment Details"
+      description: "OS, browser, device, version, etc."
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "🔁 Steps to Reproduce"
+      description: "Explain how someone else can experience this issue."
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "📋 Logs / Screenshots (Optional)"
+      description: "Paste logs or upload visuals that show the issue."
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "🙌 Contributor Checklist"
+      options:
+        - label: "I agree to follow this project's Code of Conduct"
+        - label: "I want to work on this issue"
+        - label: "I am a GSSOC'25 contributor"

--- a/.github /ISSUE_TEMPLATE/question_help.yml
+++ b/.github /ISSUE_TEMPLATE/question_help.yml
@@ -1,0 +1,34 @@
+name: "❓ Question / Help"
+description: "Ask a question or request help"
+title: "[Help] <short-title>"
+labels: ["question", "needs-triage"]
+assignees: []
+
+body:
+  - type: checkboxes
+    id: search
+    attributes:
+      label: "🔍 Have You Searched Existing Issues for the same Question?"
+      options:
+        - label: "I have searched the existing issues to avoid duplicates"
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: "🧠 What's Your Question?"
+      description: "Be specific so others can help you quickly."
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "📘 Context"
+      description: "Include screenshots, links, or any other relevant info."
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "🙌 Contributor Checklist"
+      options:
+        - label: "I have searched existing issues"
+        - label: "I agree to follow this project's Code of Conduct"

--- a/.github /ISSUE_TEMPLATE/ui_ux_suggestion.yml
+++ b/.github /ISSUE_TEMPLATE/ui_ux_suggestion.yml
@@ -1,0 +1,33 @@
+name: "🎨 UI/UX Suggestion"
+description: "Suggest improvements for the user interface or experience"
+title: "[UI/UX] <short-title>"
+labels: ["design", "needs-triage"]
+assignees: []
+
+body:
+  - type: textarea
+    id: current
+    attributes:
+      label: "🖼️ Current UI/UX Behavior"
+      description: "Describe how the interface currently behaves or looks."
+
+  - type: textarea
+    id: improvement
+    attributes:
+      label: "✨ Suggested Improvement"
+      description: "What would you like to change or add?"
+
+  - type: textarea
+    id: visuals
+    attributes:
+      label: "📎 Screenshots / Visual Aids"
+      description: "Mockups or screenshots help others understand your suggestion."
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "🙌 Contributor Checklist"
+      options:
+        - label: "I agree to follow this project's Code of Conduct"
+        - label: "I am a GSSOC'25 contributor"
+        - label: "I want to work on this issue"


### PR DESCRIPTION
Summary
This PR adds a standardized GitHub Issue Template under .github/ISSUE_TEMPLATE/.

Details
Provides a clear format for reporting bugs 🐛, feature requests ✨, and enhancements ⚡,etc.
Includes sections for description, steps to reproduce, expected behavior, screenshots, suggested solution, and additional context.
Helps maintainers quickly understand and categorize issues.
Improves contributor experience by making issue reporting consistent.
Benefits
Better issue management for maintainers.
Easier onboarding for new contributors.
Professional documentation improvement.

📌 Related Issue

Closes #18 